### PR TITLE
Enhance CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  actions   Inspect ROS actions (ROS1 is not supported)
+  actions   Inspect ROS actions
   nodes     Inspect ROS nodes
   services  Inspect ROS services
   topics    Inspect ROS topics

--- a/rtui/cli.py
+++ b/rtui/cli.py
@@ -1,7 +1,7 @@
 import click
 
 from .app import InspectApp, InspectMode
-from .ros import init_ros, is_ros1
+from .ros import init_ros, is_ros2
 
 
 def inspect_common(mode: InspectMode) -> None:
@@ -27,11 +27,8 @@ def services() -> None:
     inspect_common(InspectMode.Services)
 
 
-@click.command(help="Inspect ROS actions (ROS1 is not supported)")
+@click.command(help="Inspect ROS actions")
 def actions() -> None:
-    if is_ros1():
-        print("actions command does not support ROS1")
-        return
     inspect_common(InspectMode.Actions)
 
 
@@ -46,7 +43,8 @@ def main() -> None:
     cli.add_command(nodes)
     cli.add_command(topics)
     cli.add_command(services)
-    cli.add_command(actions)
+    if is_ros2():
+        cli.add_command(actions)
     cli()
     ...
 

--- a/rtui/cli.py
+++ b/rtui/cli.py
@@ -12,7 +12,7 @@ def inspect_common(mode: InspectMode) -> None:
         ros.terminate()
 
 
-@click.command(help="Inspect ROS nodes")
+@click.command(help="Inspect ROS nodes (default)")
 def nodes() -> None:
     inspect_common(InspectMode.Nodes)
 
@@ -35,9 +35,11 @@ def actions() -> None:
     inspect_common(InspectMode.Actions)
 
 
-@click.group(help="Terminal User Interface for ROS User")
-def cli() -> None:
-    pass
+@click.group(help="Terminal User Interface for ROS User", invoke_without_command=True)
+@click.pass_context
+def cli(ctx: click.Context) -> None:
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(nodes)
 
 
 def main() -> None:


### PR DESCRIPTION
The help message was displayed when there was no subcommand (`rtui`), but now it is treated as `rtui nodes`.

## old

```sh-session
$ rtui
Usage: rtui [OPTIONS] COMMAND [ARGS]...

  Terminal User Interface for ROS User

Options:
  --help  Show this message and exit.

Commands:
  actions   Inspect ROS actions (ROS1 is not supported)
  nodes     Inspect ROS nodes
  services  Inspect ROS services
  topics    Inspect ROS topics
```

## new

```sh-session
$ rtui
```

![image](https://github.com/eduidl/rtui/assets/25898373/01cf178c-76ac-4944-9790-8f8ca9343883)

```sh-session
$ rtui --help
Usage: rtui [OPTIONS] COMMAND [ARGS]...

  Terminal User Interface for ROS User

Options:
  --help  Show this message and exit.

Commands:
  actions   Inspect ROS actions
  nodes     Inspect ROS nodes (default)
  services  Inspect ROS services
  topics    Inspect ROS topics
```
